### PR TITLE
French: Replace "depuis" with "il y a"

### DIFF
--- a/Lib/RelativeTime/Languages/French.php
+++ b/Lib/RelativeTime/Languages/French.php
@@ -19,7 +19,7 @@ class French extends LanguageAdapter
 {
     protected $strings = array(
         'now' => 'maintenant',
-        'ago' => 'depuis %s',
+        'ago' => 'il y a %s',
         'left' => '%s restant',
         'seconds' => array(
             'plural' => '%d secondes',


### PR DESCRIPTION
The original translation from 2015 translated "2 seconds ago" as 
"since 2 seconds". Which is inaccurate since every single
French I've seen translated it to (literally) "there are 2 seconds".